### PR TITLE
feat: Add workflow step for conventional release labels

### DIFF
--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -17,6 +17,34 @@
         default: '.'
         required: false
         type: string
+      days_before_issue_stale:
+        description: Number of days before an issue is considered stale.
+        default: 60
+        required: false
+        type: number
+
+      days_before_pr_stale:
+        description: Number of days before a PR is considered stale.
+        default: 60
+        required: false
+        type: number
+
+      days_before_issue_close:
+        description: >-
+          The idle number of days before closing the stale issues or
+          the stale pull requests (due to the stale label).
+        default: 5
+        required: false
+        type: number
+
+      days_before_pr_close:
+        description: >-
+          The idle number of days before closing the stale issues or
+          the stale pull requests (due to the stale label).
+        default: 10
+        required: false
+        type: number
+
 
 jobs:
   stale:

--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -62,7 +62,7 @@ jobs:
             This issue was closed because it has been stalled for 5 days with no activity.
           close-pr-message: |
             This PR was closed because it has been stalled for 10 days with no activity.
-          days-before-issue-stale: 60
-          days-before-pr-stale: 60
-          days-before-issue-close: 5
-          days-before-pr-close: 10
+          days-before-issue-stale: ${{ inputs.days_before_issue_stale }}
+          days-before-pr-stale: ${{ inputs.days_before_pr_stale }}
+          days-before-issue-close: ${{ inputs.days_before_issue_close }}
+          days-before-pr-close: ${{ inputs.days_before_pr_close }}

--- a/.github/workflows/conventional-commit.yaml
+++ b/.github/workflows/conventional-commit.yaml
@@ -79,3 +79,8 @@ jobs:
         # yamllint disable-line rule:line-length
         run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
     timeout-minutes: ${{ inputs.timeout_minutes }}
+
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1.3.1

--- a/.github/workflows/conventional-commit.yaml
+++ b/.github/workflows/conventional-commit.yaml
@@ -39,6 +39,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     runs-on: ${{ inputs.jobs_run_on }}
+    if: ${{ github.actor != 'dependabot[bot]'  || github.actor != 'pre-commit-ci[bot]'}}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,41 @@ In addition the 'subject-case' and 'body-max-line-length' checks are disabled.
 * `validate_current_commit`: Validate current commit (last commit). Default: false
 * validate_pr_commits: Validate PR commits. Default: false
 
+#### Conventional Release-Labels
+
+The conventional commit workflow will also add labels to the PR based on
+based on Conventional Commits. By default, only labels are added.
+
+These labels can be used in conjunction GitHub's
+[automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
+
+In order to use this automatic release notes feature, you must a `.github/release.yaml` file
+
+```Yaml
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking
+    - title: Exciting New Features 🎉
+      labels:
+        - feature
+    - title: Fixes 🔧
+      labels:
+        - fix
+    - title: Other Changes
+      labels:
+        - "*"
+```
+
+More info on this can be found in the [release labels action](https://github.com/bcoe/conventional-release-labels?tab=readme-ov-file#conventional-release-labels)
+and the [release-please-action](https://github.com/googleapis/release-please-action)
+
 ### local-checks.yaml
 
 These are local Actions that run for this repository. This workflow is not

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,12 @@ jobs:
   stale:
     uses: broadinstitute/shared-workflows/.github/workflows/close-stale.yaml
 ```
+#### close-stale Inputs
+
+* `days_before_issue_stale`: Number of days before an issue is considered stale. Default to 60
+* `days_before_pr_stale`: Description: Number of days before a PR is considered stale. Default to 60
+* `days_before_issue_close`: The idle number of days before closing the stale issues or the stale pull requests (due to the stale label). Defaults to 5
+* `days_before_pr_close`: The idle number of days before closing the stale issues or the stale pull requests (due to the stale label). Defaults to 10
 
 ### conventional-commit.yaml
 


### PR DESCRIPTION
This will add labels based on conventional commit messages, that can be used later in generating releases automatically.
Also added inputs for the stale issue workflow to allow users to over ride the defaults.