### PR TITLE
fix: Terragrunt command line changes in new versions

### DIFF
--- a/.github/workflows/terraform-validate.yaml
+++ b/.github/workflows/terraform-validate.yaml
@@ -17,11 +17,6 @@
         description: The environment directory from which Terragrunt should run.
         required: false
         type: string
-      terragrunt_version:
-        default: "0.85.0"
-        description: The version of Terragrunt to use when validating.
-        required: false
-        type: string
       timeout_minutes:
         description: The maximum time (in minutes) for a job to run.
         default: 5
@@ -71,20 +66,17 @@ jobs:
       - name: Check terragrunt HCL
         uses: gruntwork-io/terragrunt-action@v3
         with:
-          tg_version: "${{ inputs.terragrunt_version }}"
           tg_dir: ${{ inputs.working_directory }}
-          tg_command: hclfmt --terragrunt-check --terragrunt-diff
+          tg_command: hcl format --check --diff
       - name: Initialize Terraform
         uses: gruntwork-io/terragrunt-action@v3
         with:
-          tg_version: "${{ inputs.terragrunt_version }}"
           tg_dir:
             "${{ inputs.working_directory }}/${{ inputs.terragrunt_directory }}"
           tg_command: init
       - name: Validate Terraform
         uses: gruntwork-io/terragrunt-action@v3
         with:
-          tg_version: "${{ inputs.terragrunt_version }}"
           tg_dir:
             "${{ inputs.working_directory }}/${{ inputs.terragrunt_directory }}"
           tg_command: validate

--- a/docs/README.md
+++ b/docs/README.md
@@ -375,8 +375,6 @@ and a `terraform validate`. If `use_terragrunt` is set to `true`, a
   `1.12.2`
 - `terragrunt_directory`: The environment directory from which Terragrunt should
   run. Default: `prod`
-- `terragrunt_version`: The version of Terragrunt to use when validating.
-  Default: `0.85.0`
 - `use_terragrunt`: If set to true, use Terragrunt instead of Terraform.
   Default: `false`
 


### PR DESCRIPTION
The Terragrunt action now uses Mise to organize Terragrunt and
Terraform versions, so the terragrunt_version input has been
removed in favor of using Mise to do all version control and
software installation.
